### PR TITLE
moves ansible role to CH repo

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,7 +4,7 @@ roles:
     name: ansible-cis-amazon-linux-2
     version: "132821cdf962f8eb7bc55f7d58c4bb9359ab3b9e"
 
-  - src: https://github.com/christiangda/ansible-role-amazon-cloudwatch-agent.git
+  - src: https://github.com/companieshouse/ansible-role-amazon-cloudwatch-agent.git
     name: cloudwatch-agent
     version: "2.0.6"
 


### PR DESCRIPTION
replaces christiangda/ansible-role-amazon-cloudwatch-agent in companieshouse/amzn2-base-ami/ansible/requirements.yml