### PR TITLE
Swap root device from /dev/sda1 -> /dev/xvda

### DIFF
--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -11,7 +11,7 @@ source "amazon-ebs" "builder" {
   kms_key_id           = var.kms_key_id
 
   launch_block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = "/dev/xvda"
     volume_size = var.root_volume_size_gb
     volume_type = "gp2"
     delete_on_termination = true


### PR DESCRIPTION
Correct the root device to match that of the AMI upon which this AMI is based. I.e. `/dev/sda1` -> `/dev/xvda`

Details of the underlying image can be seen below:

```
{
    "Images": [
        {
            "Architecture": "x86_64",
            "CreationDate": "2021-12-01T19:55:46.000Z",
            "ImageId": "ami-029ed17b4ea379178",
            "ImageLocation": "amazon/amzn2-ami-hvm-2.0.20211201.0-x86_64-gp2",
            "ImageType": "machine",
            "Public": true,
            "OwnerId": "137112412989",
            "PlatformDetails": "Linux/UNIX",
            "UsageOperation": "RunInstances",
            "State": "available",
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/xvda",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "SnapshotId": "snap-09385a49a8bbca6b9",
                        "VolumeSize": 8,
                        "VolumeType": "gp2",
                        "Encrypted": false
                    }
                }
            ],
            "Description": "Amazon Linux 2 AMI 2.0.20211201.0 x86_64 HVM gp2",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "ImageOwnerAlias": "amazon",
            "Name": "amzn2-ami-hvm-2.0.20211201.0-x86_64-gp2",
            "RootDeviceName": "/dev/xvda",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "VirtualizationType": "hvm"
        }
    ]
}
```

Resolves: DVOP-2024