### PR TITLE
Implement clamav_ng role

### DIFF
--- a/ansible/host_vars/amzn2-base.yml
+++ b/ansible/host_vars/amzn2-base.yml
@@ -29,8 +29,6 @@ cwa_conf_json_file_content: "{{ lookup('file', 'files/cloudwatch-config.json') }
 epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7"
 
-clamav_mirror: http://clamav-mirror.sharedservices.aws.internal
-
 cis_enable_rsyslog: false
 cis_apply_level_2_profile: true
 cis_level_1_exclusions:
@@ -58,3 +56,6 @@ cis_level_1_exclusions:
   - "3.4.3" #/etc/hosts.deny
 cis_level_2_exclusions: 
   - "6.1.1"
+
+## clamav_ng Variables
+clamav_ng_freshclam_privatemirror: "clamav-mirror.{{ clamav_ng_freshclam_privatemirror_domain }}"

--- a/ansible/host_vars/amzn2-base.yml
+++ b/ansible/host_vars/amzn2-base.yml
@@ -58,4 +58,4 @@ cis_level_2_exclusions:
   - "6.1.1"
 
 ## clamav_ng Variables
-clamav_ng_freshclam_privatemirror: "clamav-mirror.{{ clamav_ng_freshclam_privatemirror_domain }}"
+clamav_ng_freshclam_privatemirror: clamav-mirror.companieshouse.gov.uk

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -17,7 +17,7 @@
     - amzn2-epel
     - ch_collections.base.os_package_control
     - ch_collections.base.pip
-    - ch_collections.base.clamav
+    - companieshouse.security.clamav_ng
     - cloudwatch-agent
     - ch_collections.base.cloudwatch_agent_helper
     - ch_collections.base.auditd

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -19,4 +19,4 @@ collections:
   - name: ansible.posix
     version: 1.5.4
   - name: companieshouse.security
-    version: 1.0.20
+    version: 1.0.21

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -16,4 +16,7 @@ collections:
     version: 4.8.0
   - name: https://github.com/companieshouse/ansible-collections.git#ch_collections/security_banner
     type: git
-    
+  - name: ansible.posix
+    version: 1.5.4
+  - name: companieshouse.security
+    version: 1.0.20

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -10,4 +10,11 @@ build {
       "-e", "aws_region=${var.aws_region}"
     ]
   }
+
+  provisioner "shell" {
+    inline = [
+      "sudo find /root /home -name authorized_keys -delete",
+      "sudo find /root /home -name '.*history' -delete"
+    ]
+  }
 }

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -7,7 +7,8 @@ build {
     host_alias = "${var.ansible_host_alias}"
     playbook_file = "${var.playbook_file_path}"
     extra_arguments  = [
-      "-e", "aws_region=${var.aws_region}"
+      "-e", "aws_region=${var.aws_region}",
+      "-e", "clamav_ng_freshclam_privatemirror_domain=${var.clamav_ng_freshclam_privatemirror_domain}"
     ]
   }
 

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -7,8 +7,7 @@ build {
     host_alias = "${var.ansible_host_alias}"
     playbook_file = "${var.playbook_file_path}"
     extra_arguments  = [
-      "-e", "aws_region=${var.aws_region}",
-      "-e", "clamav_ng_freshclam_privatemirror_domain=${var.clamav_ng_freshclam_privatemirror_domain}"
+      "-e", "aws_region=${var.aws_region}"
     ]
   }
 

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -5,7 +5,6 @@ source "amazon-ebs" "builder" {
   communicator              = "ssh"
   force_delete_snapshot     = var.force_delete_snapshot
   force_deregister          = var.force_deregister
-  imds_support              = "v2.0"
   instance_type             = var.aws_instance_type
   region                    = var.aws_region
   ssh_clear_authorized_keys = var.ssh_clear_authorized_keys
@@ -22,12 +21,6 @@ source "amazon-ebs" "builder" {
     throughput            = var.root_volume_throughput
     volume_size           = var.root_volume_size_gb
     volume_type           = "gp3"
-  }
-
-  metadata_options {
-    http_endpoint               = "enabled"
-    http_tokens                 = "required"
-    http_put_response_hop_limit = 1
   }
 
   security_group_filter {

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -5,6 +5,7 @@ source "amazon-ebs" "builder" {
   communicator              = "ssh"
   force_delete_snapshot     = var.force_delete_snapshot
   force_deregister          = var.force_deregister
+  imds_support              = "v2.0"
   instance_type             = var.aws_instance_type
   region                    = var.aws_region
   ssh_clear_authorized_keys = var.ssh_clear_authorized_keys
@@ -21,6 +22,12 @@ source "amazon-ebs" "builder" {
     throughput            = var.root_volume_throughput
     volume_size           = var.root_volume_size_gb
     volume_type           = "gp3"
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
   }
 
   security_group_filter {

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -1,20 +1,26 @@
 source "amazon-ebs" "builder" {
-  ami_name             = "${var.ami_name_prefix}-${var.version}"
-  ami_users            = var.ami_account_ids
-  communicator         = "ssh"
-  instance_type        = var.aws_instance_type
-  region               = var.aws_region
-  ssh_private_key_file = var.ssh_private_key_file
-  ssh_username         = var.ssh_username
-  ssh_keypair_name     = "packer-builders-${var.aws_region}"
-  iam_instance_profile = "packer-builders-${var.aws_region}"
-  kms_key_id           = var.kms_key_id
+  ami_name                  = "${var.ami_name_prefix}-${var.version}"
+  ami_regions               = var.ami_regions
+  ami_users                 = var.ami_account_ids
+  communicator              = "ssh"
+  force_delete_snapshot     = var.force_delete_snapshot
+  force_deregister          = var.force_deregister
+  instance_type             = var.aws_instance_type
+  region                    = var.aws_region
+  ssh_clear_authorized_keys = var.ssh_clear_authorized_keys
+  ssh_private_key_file      = var.ssh_private_key_file
+  ssh_username              = var.ssh_username
+  ssh_keypair_name          = "packer-builders-${var.aws_region}"
+  iam_instance_profile      = "packer-builders-${var.aws_region}"
+  kms_key_id                = var.kms_key_id
 
   launch_block_device_mappings {
-    device_name = "/dev/xvda"
-    volume_size = var.root_volume_size_gb
-    volume_type = "gp2"
     delete_on_termination = true
+    device_name           = "/dev/xvda"
+    iops                  = var.root_volume_iops
+    throughput            = var.root_volume_throughput
+    volume_size           = var.root_volume_size_gb
+    volume_type           = "gp3"
   }
 
   security_group_filter {
@@ -39,6 +45,17 @@ source "amazon-ebs" "builder" {
     }
     most_free = true
     random = false
+  }
+
+  run_tags = {
+    AMI     = "${var.ami_name_prefix}"
+    Name    = "packer-builder-${var.ami_name_prefix}-${var.version}"
+    Service = "packer-builder"
+  }
+
+  run_volume_tags = {
+    Builder = "packer-builder"
+    Name    = "${var.ami_name_prefix}-${var.version}"
   }
 
   tags = {

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -114,3 +114,9 @@ variable "kms_key_id" {
   default     = null
   description = "KMS key ID, arn or alias to use for root volume encryption in the main region. If encrypt_boot is true and this is left null, the AWS default key is used"
 }
+
+variable "clamav_ng_freshclam_privatemirror_domain" {
+  type        = string
+  default     = ""
+  description = "The domain name to use when defining the private mirror for the clamav_ng Ansible role"
+}

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -3,6 +3,12 @@ variable "ami_account_ids" {
   description = "A list of account IDs that have access to launch the resulting AMI(s)"
 }
 
+variable "ami_regions" {
+  type        = list(string)
+  default     = ["eu-west-2"]
+  description = "A list of AWS regions that the AMI will be made available in"
+}
+
 variable "ami_name_prefix" {
   type        = string
   default     = "amzn2-base"
@@ -44,6 +50,18 @@ variable "aws_subnet_filter_name" {
   description = "The subnet filter string. Any filter described by the DescribeSubnets API documentation is valid. If multiple subnets match then the one with the most IPv4 addresses free will be used"
 }
 
+variable "force_delete_snapshot" {
+  type        = bool
+  default     = false
+  description = "Delete snapshots associated with AMIs, which have been deregistered by force_deregister"
+}
+
+variable "force_deregister" {
+  type        = bool
+  default     = false
+  description = "Deregister an existing AMI if one with the same name already exists"
+}
+
 variable "playbook_file_path" {
   type        = string
   default     = "../ansible/playbook.yml"
@@ -54,6 +72,24 @@ variable "root_volume_size_gb" {
   type        = number
   default     = 20
   description = "The EC2 instance root volume size in Gibibytes (GiB)"
+}
+
+variable "root_volume_throughput" {
+  type        = number
+  default     = 125
+  description = "The EC2 instance root volume throughput (MiB/s)"
+}
+
+variable "root_volume_iops" {
+  type        = number
+  default     = 3000
+  description = "The EC2 instance root volume IOPS"
+}
+
+variable "ssh_clear_authorized_keys" {
+  type        = bool
+  default     = true
+  description = "Defines whether the authorized_keys file should be cleared, post-build"
 }
 
 variable "ssh_private_key_file" {

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -114,9 +114,3 @@ variable "kms_key_id" {
   default     = null
   description = "KMS key ID, arn or alias to use for root volume encryption in the main region. If encrypt_boot is true and this is left null, the AWS default key is used"
 }
-
-variable "clamav_ng_freshclam_privatemirror_domain" {
-  type        = string
-  default     = ""
-  description = "The domain name to use when defining the private mirror for the clamav_ng Ansible role"
-}


### PR DESCRIPTION
Implements the `clamav_ng` role
- Add `ansible.posix` and `companieshouse.security` collection requirements
- Replace playbook call to `ch_collections.base.clamav` with `companieshouse.security.clamav_ng`
- Add host_vars entry

Update Packer build
- Add `ami_regions` var to allow AMI to be optionally shared with additional regions
- Add `force_delete_snapshot` and `force_deregister` to better support feature builds
- Add `ssh_clear_authorized_keys` to remove packer build-time key
- Update `launch_block_device_mappings` for gp3 volumes
- Added runtime tags for better instance identification
- Add inline shell provisioning step to clear history and `authorized_keys` 